### PR TITLE
Misclassified points only valid where we have an extracted elevation value

### DIFF
--- a/intertidal/elevation.py
+++ b/intertidal/elevation.py
@@ -538,11 +538,6 @@ def pixel_uncertainty(
     misclassified_all = misclassified_wet | misclassified_dry
     misclassified_ds = flat_ds.where(misclassified_all).drop("variable")
 
-    # Calculate sum of misclassified points
-    misclassified_sum = misclassified_all.sum(dim="time").rename(
-        "misclassified_px_count"
-    )
-
     # Calculate uncertainty by taking the Median Absolute Deviation of
     # all misclassified points.
     if method == "mad":
@@ -577,6 +572,13 @@ def pixel_uncertainty(
 
     # Subtract low from high DEM to summarise uncertainy range
     dem_flat_uncertainty = dem_flat_high - dem_flat_low
+
+    # Calculate sum of misclassified points
+    misclassified_sum = (
+        misclassified_all.sum(dim="time")
+        .rename("misclassified_px_count")
+        .where(~flat_dem.elevation.isnull())
+    )
 
     return (
         dem_flat_low,


### PR DESCRIPTION
Tiny bugfix to fix an issue where the `misclassified_px_count` had a value of 0 even though we had no elevation data - this didn't make sense, as it is impossible to identify misclassified points without an elevation value to test against.

Fixed by setting any misclassified pixel counts to NaN if outside of our modelled elevation pixels.

Before/after:
![image](https://github.com/GeoscienceAustralia/dea-intertidal/assets/17680388/5b8615ac-ef92-4fb7-b850-92870259998f)
