### PR TITLE
Fix incorrect Sentinel-2 band in virtual product config

### DIFF
--- a/configs/dea_virtual_product_landsat_s2.yaml
+++ b/configs/dea_virtual_product_landsat_s2.yaml
@@ -181,7 +181,7 @@ products:
                      formula: nbart_swir_2
                      dtype: float32
                  swir2: 
-                     formula: nbart_swir_2
+                     formula: nbart_swir_3
                      dtype: float32
                  cloud_mask: oa_s2cloudless_mask
                  contiguity: oa_nbart_contiguity


### PR DESCRIPTION
@vnewey picked up this great catch: we're using the wrong SWIR 2 band in the Sentinel-2 virtual product: it should point to swir_3, not swir_2. 

This means the composites are a bit dodgy at the moment - will need to re-run them at some point using the correct band.