### PR TITLE
Dem_s update in connectivity function call

### DIFF
--- a/intertidal/extents.py
+++ b/intertidal/extents.py
@@ -132,7 +132,7 @@ def load_connectivity_mask(
     dc,
     geobox,
     product="ga_srtm_dem1sv1_0",
-    elevation_band="dem_h",
+    elevation_band="dem_s",
     resampling="bilinear",
     buffer=20000,
     preprocess=None,
@@ -160,7 +160,7 @@ def load_connectivity_mask(
         Defaults to "ga_srtm_dem1sv1_0".
     elevation_band : str, optional
         The name of the band containing elevation data. Defaults to
-        "height_depth".
+        "height_smoothed".
     resampling : str, optional
         The resampling method to use, by default "bilinear".
     buffer : int, optional

--- a/notebooks/Intertidal_workflow.ipynb
+++ b/notebooks/Intertidal_workflow.ipynb
@@ -1031,10 +1031,13 @@
     "    dc=dc,\n",
     "    geobox=satellite_ds.odc.geobox,\n",
     "    product='ga_srtm_dem1sv1_0',\n",
-    "    elevation_band='dem_h',\n",
+    "    elevation_band='dem_s',\n",
     "    resampling='bilinear',\n",
     "    buffer=20000,\n",
     "    max_threshold=100,\n",
+    "    add_mangroves=False,\n",
+    "    correct_hat=False,\n",
+    "    mask_filters=[(\"dilation\", 3)],\n",
     ")"
    ]
   },

--- a/tests/test_intertidal.py
+++ b/tests/test_intertidal.py
@@ -55,7 +55,6 @@ def test_intertidal_cli():
             "0.0.1",
             "--tide_model",
             "FES2014",
-
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_intertidal.py
+++ b/tests/test_intertidal.py
@@ -54,7 +54,7 @@ def test_intertidal_cli():
             "--output_version",
             "0.0.1",
             "--tide_model",
-            "FES2014",
+            "EOT20",
         ],
     )
     assert result.exit_code == 0

--- a/tests/test_intertidal.py
+++ b/tests/test_intertidal.py
@@ -54,7 +54,8 @@ def test_intertidal_cli():
             "--output_version",
             "0.0.1",
             "--tide_model",
-            "EOT20",
+            "FES2014",
+
         ],
     )
     assert result.exit_code == 0


### PR DESCRIPTION
This PR replaces the hydrological SRTM dem layer (dem_h) with the smoothed raw SRTM dem (dem_s) in our connectivity masking function call. The PR swaps the default value in the function call from dem_h to dem_s and updates the explicit use of the function in the intertidal_workflow notebook.
Both layers handle nodata values differently but I have confirmed that the difference does not impact the outputs in the connectivity masking function (figure 1).
![image](https://github.com/user-attachments/assets/19679ffd-1750-44c0-b8ab-a2833c273d40)
This figure details the resulting connectivity masks, calculated using a) dem_h, b) dem_s (applied as per (a), where nodata values form the starting point for the cost-distance mask), d) dem_s, where 0 m elevations are used as the base of the cost-distance mask and c) the (null) difference between (b) and (d), showing that our code produces the same outcomes, regardless of the nodata or 0 m elevation baseline. Consequently, our extents.load_connectivity_mask function call has not been changed to accommodate the new dem input layer.