### PR TITLE
Fix change in xarray that requires .item() to be called on max()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@
 !*.dockerignore
 !*Dockerfile
 !tests/*.jpg
+
+build

--- a/intertidal/elevation.py
+++ b/intertidal/elevation.py
@@ -426,7 +426,7 @@ def pixel_dem(
         print(f"Applying tidal interval interpolation to {interp_intervals} intervals")
         interval_ds = interval_ds.interp(
             coords={
-                "interval": np.linspace(0, interval_ds.interval.max(), interp_intervals)
+                "interval": np.linspace(0, interval_ds.interval.max().item(), interp_intervals)
             },
             method="linear",
             # Required as recent versions of xarray return new coord as a variable


### PR DESCRIPTION
A fix for newer versions of xarray, I'm assuming.

Was getting an exception without this.

Also, without using newer eodatasets, other things were failing, something about LocalConfig.